### PR TITLE
[CI] Run test on node-backend folder

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,55 @@
+name: Node Test
+
+on:
+  pull_request:
+    paths:
+      - 'node-backend/**'
+      - '.github/workflows/backend-test.yml'
+  workflow_dispatch: ~
+
+jobs:
+  backend_test:
+    name: Backend Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16.x]
+        mongodb-version: ['4.4']
+
+    env:
+      working_directory: ./node-backend
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: "${{ matrix.node-version }}"
+
+      - name: Get Npm cache directory
+        id: npm-cache
+        run: echo "::set-output name=dir::$(npm config get cache)"
+        working-directory: ${{ env.working_directory }}
+
+      - name: Cache Npm
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: ${{ runner.os }}-node-back-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-back-
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.8.0
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+
+      - name: Install JS dependencies
+        run: npm install
+        working-directory: ${{ env.working_directory }}
+
+      - name: Run test npm
+        run: npm test
+        working-directory: ${{ env.working_directory }}


### PR DESCRIPTION
When a PR is submitted and changes are made in `node-backend` folder or in the github action file run `npm test`.

Use [mongodb-action](https://github.com/supercharge/mongodb-github-action) for now.
During [my test](https://github.com/yalefresne/cartel/actions/runs/3184242204/usage) billing time was 0 second, but keep eyes on actions time usage.

Action did not run on my PR on this repo, but run [here](https://github.com/yalefresne/cartel/actions).

Close #18 